### PR TITLE
Resolves a usability issue with auth providers

### DIFF
--- a/generators/auth-provider/index.js
+++ b/generators/auth-provider/index.js
@@ -55,7 +55,7 @@ module.exports = class extends DnnGeneratorBase {
         when: !this.options.type,
         type: 'input',
         name: 'type',
-        message: 'Enter your authentication provider name type (e.g., DNN)?',
+        message: 'Enter your authentication provider name type (e.g., MyCompany)?', 
         validate: str => {
           return str.length > 0;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
No issue.  

## Description
When creating the authentication provider, the example name for the type of authentication provider was suggested to be `DNN`.  With this being the suggestion, it was way too easy for someone to actually think that was a good idea and use it.  (And who could blame them?)  Unfortunately, this would result in a provider that would not work 100% of the time, and they wouldn't have any idea why.  (It's because the built-in authentication provider already has that name.)  

This update changes the suggested name from `DNN` to `MyCompany` so it's ambiguous enough.  

## How Has This Been Tested?
Updated, compiled, and ran using the link method for dev/testing.  

## Screenshots (if appropriate):  
![image](https://github.com/UpendoVentures/generator-upendodnn/assets/938023/f65c99d6-c489-4ca5-baf0-db27642529f0)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.