### PR TITLE
Updates HCC dependency in template manifests

### DIFF
--- a/generators/hcc/templates/actiondelegate/manifest.dnn
+++ b/generators/hcc/templates/actiondelegate/manifest.dnn
@@ -17,7 +17,7 @@
       <azureCompatible>True</azureCompatible>
       <dependencies>
         <dependency type="CoreVersion">09.08.00</dependency>
-        <dependency type="managedPackage" version="3.6.0">Hotcakes.Commerce</dependency>
+        <dependency type="managedPackage" version="3.6.0">Hotcakes.Core</dependency>
       </dependencies>
       <components>
         <component type="ResourceFile">

--- a/generators/hcc/templates/creditcardgateway/manifest.dnn
+++ b/generators/hcc/templates/creditcardgateway/manifest.dnn
@@ -18,7 +18,7 @@
       <azureCompatible>True</azureCompatible>
       <dependencies>
         <dependency type="CoreVersion">09.08.00</dependency>
-        <dependency type="managedPackage" version="3.6.0">Hotcakes.Commerce</dependency>
+        <dependency type="managedPackage" version="3.6.0">Hotcakes.Core</dependency>
       </dependencies>
       <components>
 

--- a/generators/hcc/templates/giftcardgateway/manifest.dnn
+++ b/generators/hcc/templates/giftcardgateway/manifest.dnn
@@ -18,7 +18,7 @@
       <azureCompatible>True</azureCompatible>
       <dependencies>
         <dependency type="CoreVersion">09.08.00</dependency>
-        <dependency type="managedPackage" version="3.6.0">Hotcakes.Commerce</dependency>
+        <dependency type="managedPackage" version="3.6.0">Hotcakes.Core</dependency>
       </dependencies>
       <components>
 

--- a/generators/hcc/templates/paymentmethod/manifest.dnn
+++ b/generators/hcc/templates/paymentmethod/manifest.dnn
@@ -18,7 +18,7 @@
       <azureCompatible>True</azureCompatible>
       <dependencies>
         <dependency type="CoreVersion">09.08.00</dependency>
-        <dependency type="managedPackage" version="3.6.0">Hotcakes.Commerce</dependency>
+        <dependency type="managedPackage" version="3.6.0">Hotcakes.Core</dependency>
       </dependencies>
       <components>
 

--- a/generators/hcc/templates/taxprovider/manifest.dnn
+++ b/generators/hcc/templates/taxprovider/manifest.dnn
@@ -18,7 +18,7 @@
       <azureCompatible>True</azureCompatible>
       <dependencies>
         <dependency type="CoreVersion">09.08.00</dependency>
-        <dependency type="managedPackage" version="3.6.0">Hotcakes.Commerce</dependency>
+        <dependency type="managedPackage" version="3.6.0">Hotcakes.Core</dependency>
       </dependencies>
       <components>
       

--- a/generators/hcc/templates/workflow/manifest.dnn
+++ b/generators/hcc/templates/workflow/manifest.dnn
@@ -17,7 +17,7 @@
       <azureCompatible>True</azureCompatible>
       <dependencies>
         <dependency type="CoreVersion">09.08.00</dependency>
-        <dependency type="managedPackage" version="3.6.0">Hotcakes.Commerce</dependency>
+        <dependency type="managedPackage" version="3.6.0">Hotcakes.Core</dependency>
       </dependencies>
       <components>
         <component type="ResourceFile">


### PR DESCRIPTION
## Related to PR
Update #236 

## Description
Update the manifests for each HCC extension to be at version 3.6.0. The reference was pointing to `Hotcakes.Commerce` and the correct reference is `Hotcakes.Core`.

## How Has This Been Tested?

Ran the generator locally.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.