### PR TITLE
Fix_Debug_Build_Path_for_HCC_Payment_Method_Files

### DIFF
--- a/generators/common/src-hotcakes-hcc/paymentmethod/Module.build
+++ b/generators/common/src-hotcakes-hcc/paymentmethod/Module.build
@@ -7,9 +7,9 @@
     <BuildScriptsPath>$(MSBuildProjectDirectory)\..\..\Build</BuildScriptsPath>
     <WebsitePath>$(MSBuildProjectDirectory)\..\..\Website</WebsitePath>
     <WebsiteInstallPath>$(WebsitePath)\Install\Module</WebsiteInstallPath>
-     <FullModulePath>$(WebsitePath)\DesktopModules\Hotcakes\Core\Admin\Parts\PaymentMethods\$(DNNFileName)</FullModulePath>
+    <FullModulePath>$(WebsitePath)\DesktopModules\Hotcakes\Core\Admin\Parts\PaymentMethods\$(DNNFileName)</FullModulePath>
     <ModulePathFiles>$(MSBuildProjectDirectory)\DesktopModules\Hotcakes\Core\Admin\Parts\PaymentMethods\$(DNNFileName)</ModulePathFiles>
-    <FullModulePortalPath>$(WebsitePath)\Portals\_default\HotcakesViews\_default\Views\$(ModulePath)</FullModulePortalPath>
+    <FullModulePortalPath>$(WebsitePath)\Portals\</FullModulePortalPath>
   </PropertyGroup>
   <Import Project="$(BuildScriptsPath)\ModulePackage.Targets" />
   <Target Name="AfterBuild" DependsOnTargets="CopyBin;GetFiles;DebugProject;PackageModule">


### PR DESCRIPTION
## Related to Issue
Fixes #216

## Description
This update resolves the issue referred to in the Issue #216 . Updated the paths in the Module.Build File to fix the issue of where to copy files from the `/Website/Portals/` folder when building in debug mode.

## How Has This Been Tested?
Locally generated solution from upendo-generator

## Screenshots (if appropriate):
![Folder](https://github.com/UpendoVentures/generator-upendodnn/assets/34067433/7e3110ad-2b09-48b5-82be-9c4d88409e4c)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.