### PR TITLE
Update vue.config.js

### DIFF
--- a/generators/spa/templates/Vue3JS/common/client-app/vue.config.js
+++ b/generators/spa/templates/Vue3JS/common/client-app/vue.config.js
@@ -2,5 +2,6 @@ const { defineConfig } = require('@vue/cli-service')
 module.exports = defineConfig({
   transpileDependencies: true,
   outputDir: "../Scripts/client-app/",
+  publicPath: "/DesktopModules/<%= friendlyName %>/Scripts/client-app/",
   filenameHashing: false
 })


### PR DESCRIPTION
Fix for bug: Calling incorrect URL when loading JavaScrpt Chucks

<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #298 

## Description
Adds a public path option to the vue.config.js so that the correct URL will be used when loading JavaScript chunks.

## How Has This Been Tested?
1. Changed the file in the generator template.
2. Used the generator to create an new Vue 3 module.
3. Changed the module to use Lazy Loading as described in Issue #298.
4. Installed the module on multiple pages, subpages and sites and verified the component to be  Lazy Loaded worked correctly along with the rest of the module.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.