### PR TITLE
Fix hcc search view

### DIFF
--- a/generators/hcc/templates/viewset/Portals/_default/HotcakesViews/MyBootstrap4/Views/Search/Index.cshtml
+++ b/generators/hcc/templates/viewset/Portals/_default/HotcakesViews/MyBootstrap4/Views/Search/Index.cshtml
@@ -19,7 +19,7 @@
                 <div class="row">
                     <div class="col-12 text-right mb-3">
                         <h6>
-                            @Model.Products.Count 
+                            @Model.PagerData.TotalItems 
                             @if (Model.Products.Count > 1){
                                 @Localization.GetString("ProductsFound")
                             }else{

--- a/generators/hcc/templates/viewset/Portals/_default/HotcakesViews/MyViewSet/Views/Search/Index.cshtml
+++ b/generators/hcc/templates/viewset/Portals/_default/HotcakesViews/MyViewSet/Views/Search/Index.cshtml
@@ -18,7 +18,7 @@
             <div class="row">
                 <div class="col-12 text-right margin-bottom-md">
                     <h6>
-                        @Model.Products.Count 
+                        @Model.PagerData.TotalItems 
                         @if (Model.Products.Count > 1){
                             @Localization.GetString("ProductsFound")
                         }else{

--- a/generators/hcc/templates/viewset/Portals/_default/HotcakesViews/MyViewSet/Views/Views/Search/Index.cshtml
+++ b/generators/hcc/templates/viewset/Portals/_default/HotcakesViews/MyViewSet/Views/Views/Search/Index.cshtml
@@ -18,7 +18,7 @@
             <div class="row">
                 <div class="col-12 text-right margin-bottom-md">
                     <h6>
-                        @Model.Products.Count 
+                        @Model.PagerData.TotalItems 
                         @if (Model.Products.Count > 1){
                             @Localization.GetString("ProductsFound")
                         }else{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In this PR, the HCC viewset templates were updated to resolve an issue in the search results view, which previously only displayed the total products for the active page. Now, the total number of products found is correctly displayed in the view.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I created a new solution and generated an HCC viewset using the Upendo generator in my local environment. Then, I created the installer and tested it on a clean solution with DNN 9.13.04 and HCC 3.08.01, where it worked as expected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.