### PR TITLE
Update Library.build

### DIFF
--- a/generators/common/src-library-hcc/Library.build
+++ b/generators/common/src-library-hcc/Library.build
@@ -26,12 +26,12 @@
     <SymbolsInclude Include="ReleaseNotes.txt" />
   </ItemGroup>
   <ItemGroup>
-    <BinInstallInclude Include="$(MSBuildProjectDirectory)\bin\*.dll" />
+    <BinInstallInclude Include="$(MSBuildProjectDirectory)\bin\*.dll" Exclude="$(MSBuildProjectDirectory)\bin\DotNetNuke*;$(MSBuildProjectDirectory)\bin\Telerik*;$(MSBuildProjectDirectory)\bin\System.*;$(MSBuildProjectDirectory)\bin\Microsoft.*;$(MSBuildProjectDirectory)\bin\Newtonsoft.Json.*" />
   </ItemGroup>
   <Target Name="CopyBin">
     <ItemGroup>
-      <BinSourceInclude Include="$(MSBuildProjectDirectory)\bin\*.dll" />
-      <BinSourceInclude Include="$(MSBuildProjectDirectory)\bin\*.pdb" />
+      <BinSourceInclude Include="$(MSBuildProjectDirectory)\bin\*.dll" Exclude="$(MSBuildProjectDirectory)\bin\DotNetNuke*;$(MSBuildProjectDirectory)\bin\Telerik*;$(MSBuildProjectDirectory)\bin\System.*;$(MSBuildProjectDirectory)\bin\Microsoft.*;$(MSBuildProjectDirectory)\bin\Newtonsoft.Json.*" />
+      <BinSourceInclude Include="$(MSBuildProjectDirectory)\bin\*.pdb" Exclude="$(MSBuildProjectDirectory)\bin\DotNetNuke*;$(MSBuildProjectDirectory)\bin\Telerik*;$(MSBuildProjectDirectory)\bin\System.*;$(MSBuildProjectDirectory)\bin\Microsoft.*;$(MSBuildProjectDirectory)\bin\Newtonsoft.Json.*" />
     </ItemGroup>
     <Copy SourceFiles="@(BinSourceInclude)" DestinationFolder="$(WebsitePath)/bin" />
   </Target>


### PR DESCRIPTION
Add missing Exclude attribute for HCC projects

<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes # [331](https://github.com/UpendoVentures/generator-upendodnn/issues/331)

## Description
This PR updates the Upendo generator to include the `Exclude` attribute section in the `Library.build` file for HCC Action Delegate Integration projects. This ensures that all generated projects include the necessary exclusions by default, preventing potential deployment issues.  

## How Has This Been Tested?
- Generated an HCC Action Delegate Integration project using the updated generator.  
- Verified that the generated `Library.build` file contains the `Exclude` attribute section.  
- Deployed the generated project to a DNN instance to confirm that no errors occurred.  

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.